### PR TITLE
Support Negative Mode Spectra

### DIFF
--- a/ProteoformExplorer.Core/CachedSpectraFileData.cs
+++ b/ProteoformExplorer.Core/CachedSpectraFileData.cs
@@ -77,7 +77,6 @@ namespace ProteoformExplorer.Core
                     }
                 }
 
-
                 species.DeconvolutionFeature.FindAnnotatedEnvelopesInData(new KeyValuePair<string, CachedSpectraFileData>(DataFile.Key, this));
                 foreach (AnnotatedEnvelope envelope in species.DeconvolutionFeature.AnnotatedEnvelopes)
                 {

--- a/ProteoformExplorer.Core/CachedSpectraFileData.cs
+++ b/ProteoformExplorer.Core/CachedSpectraFileData.cs
@@ -61,7 +61,7 @@ namespace ProteoformExplorer.Core
                         // (i.e., from a top-down search program)
                         species.Identification.GetPrecursorInfoForIdentification();
 
-                        if (species.Identification.PrecursorChargeState > 0 && species.Identification.OneBasedPrecursorScanNumber > 0)
+                        if (species.Identification.PrecursorChargeState != 0 && species.Identification.OneBasedPrecursorScanNumber > 0)
                         {
                             species.DeconvolutionFeature = new DeconvolutionFeature(species.Identification, new KeyValuePair<string, CachedSpectraFileData>(DataFile.Key, this));
                         }

--- a/ProteoformExplorer.Core/DeconvolutionFeature.cs
+++ b/ProteoformExplorer.Core/DeconvolutionFeature.cs
@@ -93,7 +93,7 @@ namespace ProteoformExplorer.Core
         {
             id.GetPrecursorInfoForIdentification();
 
-            if (id.OneBasedPrecursorScanNumber <= 0 || id.PrecursorChargeState <= 0)
+            if (id.OneBasedPrecursorScanNumber <= 0 || id.PrecursorChargeState == 0)
             {
                 // TODO: some kind of error here?
                 return;

--- a/ProteoformExplorer.Core/IO/IFileProcessingStrategy.cs
+++ b/ProteoformExplorer.Core/IO/IFileProcessingStrategy.cs
@@ -19,7 +19,7 @@ public class MetaMorpheusProcessingStrategy : IFileProcessingStrategy
         List<AnnotatedSpecies> species = new List<AnnotatedSpecies>(psms.Count);
         foreach (var spectralMatch in psms)
         {
-            var id = new Identification(spectralMatch.BaseSequence, spectralMatch.FullSequence, spectralMatch.MonoisotopicMass, spectralMatch.ChargeState,
+            var id = new Identification(spectralMatch.BaseSequence, spectralMatch.FullSequence, spectralMatch.PrecursorMass, spectralMatch.ChargeState,
                 spectralMatch.PrecursorScanNum, spectralMatch.Ms2ScanNumber, spectralMatch.FileNameWithoutExtension, dataset);
 
             species.Add(new AnnotatedSpecies(id));

--- a/ProteoformExplorer.Core/Identification.cs
+++ b/ProteoformExplorer.Core/Identification.cs
@@ -16,6 +16,7 @@ namespace ProteoformExplorer.Core
         public int IdentificationScanNum { get; private set; }
         public string SpectraFileNameWithoutExtension { get; private set; }
         public string Dataset { get; private set; }
+        public Polarity Polarity { get; private set; }
 
         public Identification(string baseSequence, string modifiedSequence, double monoMass, int chargeState,
             int precursorScanNum, int identificationScanNum, string spectraFileNameWithoutExtension, string dataset = "")
@@ -60,10 +61,10 @@ namespace ProteoformExplorer.Core
                 }
             }
 
-            Polarity polarity = file.Value.GetOneBasedScan(IdentificationScanNum).Polarity;
+            Polarity = file.Value.GetOneBasedScan(IdentificationScanNum).Polarity;
 
             // get the precursor charge
-            if (OneBasedPrecursorScanNumber > 0 && ((PrecursorChargeState <= 0 && polarity == Polarity.Positive) || (PrecursorChargeState >= 0 && polarity == Polarity.Negative)))
+            if (OneBasedPrecursorScanNumber > 0 && ((PrecursorChargeState <= 0 && Polarity == Polarity.Positive) || (PrecursorChargeState >= 0 && Polarity == Polarity.Negative)))
             {
                 var fragmentationScan = file.Value.GetOneBasedScan(IdentificationScanNum);
 

--- a/ProteoformExplorer.Core/Identification.cs
+++ b/ProteoformExplorer.Core/Identification.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MassSpectrometry;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -59,8 +60,10 @@ namespace ProteoformExplorer.Core
                 }
             }
 
+            Polarity polarity = file.Value.GetOneBasedScan(IdentificationScanNum).Polarity;
+
             // get the precursor charge
-            //if (OneBasedPrecursorScanNumber > 0 && PrecursorChargeState <= 0)
+            if (OneBasedPrecursorScanNumber > 0 && ((PrecursorChargeState <= 0 && polarity == Polarity.Positive) || (PrecursorChargeState >= 0 && polarity == Polarity.Negative)))
             {
                 var fragmentationScan = file.Value.GetOneBasedScan(IdentificationScanNum);
 

--- a/ProteoformExplorer.Core/InputReaderParser.cs
+++ b/ProteoformExplorer.Core/InputReaderParser.cs
@@ -20,7 +20,7 @@ namespace ProteoformExplorer.Core
             TopFD,
             Unknown
         }
-        public static List<string> AcceptedTextFileFormats = new List<string> { ".psmtsv", ".tsv", ".txt", ".feature" };
+        public static List<string> AcceptedTextFileFormats = new List<string> { ".psmtsv", ".tsv", ".osmtsv", ".txt", ".feature" };
         public static List<string> AcceptedSpectraFileFormats = new List<string> { ".raw", ".mzml" };
 
         // populated from KnownFileExtensions.txt

--- a/ProteoformExplorer.GuiFunctions/GuiSettings.cs
+++ b/ProteoformExplorer.GuiFunctions/GuiSettings.cs
@@ -45,7 +45,7 @@ namespace ProteoformExplorer.GuiFunctions
         public static double ChartAxisLabelFontSize = 13;
         public static double ChartLineWidth = 1;
         public static double AnnotatedEnvelopeLineWidth = 2;
-        public static ScottPlot.Alignment LegendLocation = ScottPlot.Alignment.UpperRight;
+        public static ScottPlot.Alignment LegendLocation = ScottPlot.Alignment.UpperLeft;
         public static bool ShowChartGrid = false;
         public static double XLabelRotation = 30;
         public static bool FillWaterfall = true;

--- a/ProteoformExplorer.GuiFunctions/PlottingFunctions.cs
+++ b/ProteoformExplorer.GuiFunctions/PlottingFunctions.cs
@@ -65,6 +65,8 @@ namespace ProteoformExplorer.GuiFunctions
                     lollipopPlot.BarWidth = (float)(GuiSettings.ChartLineWidth * GuiSettings.DpiScalingX);
                 }
             }
+
+            plot.Benchmark(false);
         }
 
         public static void StyleDashboardPlot(Plot plot)
@@ -663,6 +665,7 @@ namespace ProteoformExplorer.GuiFunctions
             }
 
             indicator.X = scan.RetentionTime;
+            indicator.Color = GuiSettings.RtIndicatorColor;
 
             // this does not seem to update properly. need to call .Render() on the WpfPlot object, not the Plot
             //plot.Render();

--- a/ProteoformExplorer.Tests/UnitTest1.cs
+++ b/ProteoformExplorer.Tests/UnitTest1.cs
@@ -168,7 +168,7 @@ namespace Test
             var spectrum = new MzSpectrum(peaks.Select(p => p.Item1).ToArray(), peaks.Select(p => p.Item2).ToArray(), true);
 
             var engine = new DeconvolutionEngine(0, 0.4, 3, 0.4, 1.5, 5, 1, 60, 2);
-            var envs = engine.Deconvolute(spectrum, spectrum.Range).ToList();
+            var envs = engine.Deconvolute(spectrum, spectrum.Range, MassSpectrometry.Polarity.Positive).ToList();
 
             List<string> output = new List<string> { DeconvolutedEnvelope.TabDelimitedHeader };
 

--- a/ProteoformExplorer.Wpf/DisplayingInWpf/SettingsViewModel.cs
+++ b/ProteoformExplorer.Wpf/DisplayingInWpf/SettingsViewModel.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Input;
 using ProteoformExplorer.GuiFunctions;
+using ScottPlot;
 
 namespace ProteoformExplorer.Wpf
 {
@@ -69,6 +70,18 @@ namespace ProteoformExplorer.Wpf
             {
                 GuiSettings.ChartLineWidth = value;
                 OnPropertyChanged(nameof(ChartLineWidth));
+            }
+        }
+
+        public ObservableCollection<Alignment> LegendLocations { get; } = [..Enum.GetValues<Alignment>()];
+
+        public Alignment LegendLocation
+        {
+            get => GuiSettings.LegendLocation;
+            set
+            {
+                GuiSettings.LegendLocation = value;
+                OnPropertyChanged(nameof(LegendLocation));
             }
         }
 

--- a/ProteoformExplorer.Wpf/Pages/DataLoading.xaml
+++ b/ProteoformExplorer.Wpf/Pages/DataLoading.xaml
@@ -77,74 +77,79 @@
         </Border>
 
         <ScrollViewer Grid.Row="1" Margin="0">
-          <ListView ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
+            <ListView ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
                     Name="filesToLoad" HorizontalAlignment="Center" 
                     KeyDown="DataLoading_OnKeyDown" SelectionMode="Single"
                     Visibility="Hidden" BorderThickness="0" Margin="0" ItemsSource="{Binding FilesToLoad}">
-              <ListView.ItemContainerStyle>
-                  <Style TargetType="ListViewItem">
-                      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                      <Setter Property="VerticalContentAlignment" Value="Stretch" />
-                      <Setter Property="Foreground" Value="{Binding ForegroundColor}"/>
-                      <Setter Property="Background" Value="{Binding BackgroundColor}"/>
-                      <Setter Property="FontSize" Value="12"/>
-                      <Setter Property="FontWeight" Value="Bold"/>
-                      <Setter Property="BorderThickness" Value="0"/>
-                      <Setter Property="Height" Value="100"/>
-                      <Setter Property="Width" Value="300"/>
-                      <Setter Property="Margin" Value="5"/>
+                <ListView.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ListView.ItemsPanel>
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+                        <Setter Property="Foreground" Value="{Binding ForegroundColor}"/>
+                        <Setter Property="Background" Value="{Binding BackgroundColor}"/>
+                        <Setter Property="FontSize" Value="12"/>
+                        <Setter Property="FontWeight" Value="Bold"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Height" Value="100"/>
+                        <Setter Property="Width" Value="300"/>
+                        <Setter Property="Margin" Value="5"/>
 
-                      <Style.Resources>
-                          <Style TargetType="Border">
-                              <Setter Property="CornerRadius" Value="10"/>
-                          </Style>
-                      </Style.Resources>
-                  </Style>
-              </ListView.ItemContainerStyle>
+                        <Style.Resources>
+                            <Style TargetType="Border">
+                                <Setter Property="CornerRadius" Value="10"/>
+                            </Style>
+                        </Style.Resources>
+                    </Style>
+                </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
-                  <DataTemplate>
-                      <Grid Margin="0" >
-                          <!-- Define the layout -->
-                          <Grid.ColumnDefinitions>
-                              <ColumnDefinition Width="*" />
+                    <DataTemplate>
+                        <Grid Margin="0" >
+                            <!-- Define the layout -->
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
-                          </Grid.ColumnDefinitions>
-                          <Grid.RowDefinitions>
-                              <RowDefinition Height="Auto" />
-                              <RowDefinition Height="*" />
-                          </Grid.RowDefinitions>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
 
-                          <!-- Remove button in the top-right corner -->
-                          <Button Content="X"
-                                  Grid.Column="1"
-                                  Grid.Row="0"
-                                  HorizontalAlignment="Right"
-                                  VerticalAlignment="Top"
-                                  Padding="5"
-                                  Margin="0"
-                                  Background="Transparent"
-                                  Foreground="{StaticResource NasturcianFlower}"
-                                  Command="{Binding RemoveFileCommand, RelativeSource={RelativeSource AncestorType=Page}}"
-                                  CommandParameter="{Binding}" />
+                            <!-- Remove button in the top-right corner -->
+                            <Button Content="X"
+                                Grid.Column="1"
+                                Grid.Row="0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Top"
+                                Padding="5"
+                                Margin="0"
+                                Background="Transparent"
+                                Foreground="{StaticResource NasturcianFlower}"
+                                Command="{Binding RemoveFileCommand, RelativeSource={RelativeSource AncestorType=Page}}"
+                                CommandParameter="{Binding}" />
 
-                          <!-- File name text in the center -->
-                          <TextBlock Text="{Binding FileNameWithExtension}"
-                                     Grid.Column="0"
-                                     Grid.ColumnSpan="2"
-                                     Grid.Row="0"
-                                     Grid.RowSpan="2"
-                                     TextWrapping="WrapWithOverflow"
-                                     HorizontalAlignment="Center"
-                                     VerticalAlignment="Center"
-                                     Margin="10"
-                                     FontSize="14"
-                                     FontWeight="Bold"
-                                     Foreground="{Binding ForegroundColor}" />
+                            <!-- File name text in the center -->
+                            <TextBlock Text="{Binding FileNameWithExtension}"
+                                    Grid.Column="0"
+                                    Grid.ColumnSpan="2"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    TextWrapping="WrapWithOverflow"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Margin="10"
+                                    FontSize="14"
+                                    FontWeight="Bold"
+                                    Foreground="{Binding ForegroundColor}" />
 
                         </Grid>
-                  </DataTemplate>
-              </ListView.ItemTemplate>
-          </ListView>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
         </ScrollViewer>
     </Grid>
 </Page>

--- a/ProteoformExplorer.Wpf/Pages/DataLoading.xaml.cs
+++ b/ProteoformExplorer.Wpf/Pages/DataLoading.xaml.cs
@@ -179,7 +179,7 @@ namespace ProteoformExplorer.Wpf
                     DataManagement.SpectraFiles.Add(fileName, new CachedSpectraFileData(kvp));
                 }
             }
-            else if (ext == ".psmtsv" || ext == ".tsv" || ext == ".txt" || ext == ".feature")
+            else if (ext == ".psmtsv" || ext == ".tsv" || ext == ".osmtsv" || ext == ".txt" || ext == ".feature")
             {
                 List<AnnotatedSpecies> items;
                 var processor = FileProcessor.GetProcessor(file.FullFilePath);

--- a/ProteoformExplorer.Wpf/Pages/ML_Trainer.xaml.cs
+++ b/ProteoformExplorer.Wpf/Pages/ML_Trainer.xaml.cs
@@ -67,7 +67,7 @@ namespace ProteoformExplorer.Wpf
                 scan = data.Value.GetOneBasedScan(scanNum);
             }
 
-            var decon = PfmXplorerUtil.DeconvolutionEngine.GetEnvelopeCandidates(scan.MassSpectrum, scan.ScanWindowRange).OrderBy(p => r.Next()).ToList();
+            var decon = PfmXplorerUtil.DeconvolutionEngine.GetEnvelopeCandidates(scan.MassSpectrum, scan.ScanWindowRange, null, scan.Polarity).OrderBy(p => r.Next()).ToList();
 
 
             currentlyDisplayedScan = scan;

--- a/ProteoformExplorer.Wpf/Pages/SettingsWindow.xaml
+++ b/ProteoformExplorer.Wpf/Pages/SettingsWindow.xaml
@@ -140,6 +140,12 @@
                 <TextBlock Text="Envelope Line Width:" VerticalAlignment="Center" Width="150" />
                 <wpf:DoubleTextBoxControl Text="{Binding AnnotatedEnvelopeLineWidth}" Width="100" />
             </StackPanel>
+
+            <!-- Legend Location -->
+            <StackPanel Orientation="Horizontal" Margin="0,5">
+                <TextBlock Text="Legend Location:" VerticalAlignment="Center" Width="150" />
+                <ComboBox ItemsSource="{Binding LegendLocations}" SelectedItem="{Binding LegendLocation}" />
+            </StackPanel>
         </StackPanel>
 
         <!-- Controls to add new entries -->


### PR DESCRIPTION
This pull request introduces several improvements and enhancements across multiple files in the `ProteoformExplorer` project. The key changes include the addition of polarity support for deconvolution and identification, improvements to charge state handling, and updates to the graphical user interface (GUI) settings and plotting functions. Below is a categorized summary of the most important changes:

### Polarity Support
* Added a `Polarity` property to `DeconvolutionFeature` and `Identification` classes to handle positive and negative polarities. This property is derived from charge states or scan data. (`ProteoformExplorer.Core/DeconvolutionFeature.cs`, [[1]](diffhunk://#diff-ec5fd2c051bae3264f51c0513db444c5ee4390c9af95a9766701336d066212eaR20) [[2]](diffhunk://#diff-ec5fd2c051bae3264f51c0513db444c5ee4390c9af95a9766701336d066212eaR31-R52); `ProteoformExplorer.Core/Identification.cs`, [[3]](diffhunk://#diff-5ce560fba7aece175b2ce6aef441c908ef67c5d94bb80b4becf14aca178f0b8aR19) [[4]](diffhunk://#diff-5ce560fba7aece175b2ce6aef441c908ef67c5d94bb80b4becf14aca178f0b8aR64-R67)
* Updated deconvolution methods to account for polarity when determining charge states and filtering envelopes. (`ProteoformExplorer.Deconvoluter/DeconvolutionEngine.cs`, [[1]](diffhunk://#diff-33da57dc7866d450071635a475129c598cdf32c7f75166b28f5140d6b6ad2f6fL152-R154) [[2]](diffhunk://#diff-33da57dc7866d450071635a475129c598cdf32c7f75166b28f5140d6b6ad2f6fL174-R190) [[3]](diffhunk://#diff-33da57dc7866d450071635a475129c598cdf32c7f75166b28f5140d6b6ad2f6fL586-R608)

### Charge State Handling
* Modified conditions for charge state validation to use `!= 0` instead of `> 0` to support both positive and negative charges. (`ProteoformExplorer.Core/CachedSpectraFileData.cs`, [[1]](diffhunk://#diff-8f6b140c261f5e20b82b640ad2a09b82b8c2ac0ced2057dfa2e1afbc8d1d8169L64-R64); `ProteoformExplorer.Core/DeconvolutionFeature.cs`, [[2]](diffhunk://#diff-ec5fd2c051bae3264f51c0513db444c5ee4390c9af95a9766701336d066212eaL96-R108)
* Improved logic for finding isotopic envelopes by iterating over charge states in both directions based on polarity. (`ProteoformExplorer.Core/DeconvolutionFeature.cs`, [ProteoformExplorer.Core/DeconvolutionFeature.csL166-R232](diffhunk://#diff-ec5fd2c051bae3264f51c0513db444c5ee4390c9af95a9766701336d066212eaL166-R232))

### GUI and Plotting Enhancements
* Changed the default legend location in plots from `UpperRight` to `UpperLeft` for better visualization. (`ProteoformExplorer.GuiFunctions/GuiSettings.cs`, [ProteoformExplorer.GuiFunctions/GuiSettings.csL48-R48](diffhunk://#diff-1234f3e87a27b7294c267812edc49830919f256ef43e0d89898f1233960178fdL48-R48))
* Added a benchmark disable call (`plot.Benchmark(false)`) to improve performance during plot rendering. (`ProteoformExplorer.GuiFunctions/PlottingFunctions.cs`, [ProteoformExplorer.GuiFunctions/PlottingFunctions.csR68-R69](diffhunk://#diff-262552de4b97fd542626705b4ddbc744d952ed9c7b6d10921024bd71728aa433R68-R69))
* Updated the retention time indicator to use a configurable color from `GuiSettings`. (`ProteoformExplorer.GuiFunctions/PlottingFunctions.cs`, [ProteoformExplorer.GuiFunctions/PlottingFunctions.csR668](diffhunk://#diff-262552de4b97fd542626705b4ddbc744d952ed9c7b6d10921024bd71728aa433R668))

### File Format Support
* Added support for a new file format `.osmtsv` in the list of accepted text file formats. (`ProteoformExplorer.Core/InputReaderParser.cs`, [ProteoformExplorer.Core/InputReaderParser.csL23-R23](diffhunk://#diff-3e7db58889bc3a2224b34a781950e6112f33ef7f03d17b1684bce707f6677c0bL23-R23))

### Code Improvements
* Replaced null and count checks with pattern matching (`AnnotatedEnvelopes is { Count: > 0 }`) for better readability. (`ProteoformExplorer.Core/DeconvolutionFeature.cs`, [ProteoformExplorer.Core/DeconvolutionFeature.csR31-R52](diffhunk://#diff-ec5fd2c051bae3264f51c0513db444c5ee4390c9af95a9766701336d066212eaR31-R52))

These changes collectively enhance the functionality, usability, and maintainability of the `ProteoformExplorer` project.